### PR TITLE
added Gin Context to authenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ func main() {
     Realm:   "test zone",
     Key:     []byte("secret key"),
     Timeout: time.Hour,
-    Authenticator: func(userId string, password string) (string, bool) {
+    Authenticator: func(userId string, password string, c *gin.Context) (string, bool) {
       if (userId == "admin" && password == "admin") || (userId == "test" && password == "test") {
         return userId, true
       }

--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -32,7 +32,7 @@ type GinJWTMiddleware struct {
 	// Callback function that should perform the authentication of the user based on userId and
 	// password. Must return true on success, false on failure. Required.
 	// Option return user id, if so, user id will be stored in Claim Array.
-	Authenticator func(userId string, password string) (string, bool)
+	Authenticator func(userId string, password string, c *gin.Context) (string, bool)
 
 	// Callback function that should perform the authorization of the authenticated user. Called
 	// only after an authentication success. Must return true on success, false on failure.

--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -144,7 +144,7 @@ func (mw *GinJWTMiddleware) LoginHandler(c *gin.Context) {
 		return
 	}
 
-	userId, ok := mw.Authenticator(loginVals.Username, loginVals.Password)
+	userId, ok := mw.Authenticator(loginVals.Username, loginVals.Password, c)
 
 	if !ok {
 		mw.unauthorized(c, http.StatusUnauthorized, "Incorrect Username / Password")

--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -34,7 +34,7 @@ func TestMissingRealm(t *testing.T) {
 	authMiddleware := &GinJWTMiddleware{
 		Key:     key,
 		Timeout: time.Hour,
-		Authenticator: func(userId string, password string) (string, bool) {
+		Authenticator: func(userId string, password string, c *gin.Context) (string, bool) {
 			if userId == "admin" && password == "admin" {
 				return "", true
 			}
@@ -68,7 +68,7 @@ func TestMissingKey(t *testing.T) {
 	authMiddleware := &GinJWTMiddleware{
 		Realm:   "test zone",
 		Timeout: time.Hour,
-		Authenticator: func(userId string, password string) (string, bool) {
+		Authenticator: func(userId string, password string, c *gin.Context) (string, bool) {
 			if userId == "admin" && password == "admin" {
 				return "", true
 			}
@@ -88,7 +88,7 @@ func TestMissingTimeOut(t *testing.T) {
 	authMiddleware := &GinJWTMiddleware{
 		Realm: "test zone",
 		Key:   key,
-		Authenticator: func(userId string, password string) (string, bool) {
+		Authenticator: func(userId string, password string, c *gin.Context) (string, bool) {
 			if userId == "admin" && password == "admin" {
 				return "", true
 			}
@@ -134,7 +134,7 @@ func TestLoginHandler(t *testing.T) {
 			// Set custom claim, to be checked in Authorizator method
 			return map[string]interface{}{"testkey": "testval", "exp": 0}
 		},
-		Authenticator: func(userId string, password string) (string, bool) {
+		Authenticator: func(userId string, password string, c *gin.Context) (string, bool) {
 			if userId == "admin" && password == "admin" {
 				return "", true
 			}
@@ -206,7 +206,7 @@ func TestParseToken(t *testing.T) {
 		Realm:   "test zone",
 		Key:     key,
 		Timeout: time.Hour,
-		Authenticator: func(userId string, password string) (string, bool) {
+		Authenticator: func(userId string, password string, c *gin.Context) (string, bool) {
 			if userId == "admin" && password == "admin" {
 				return userId, true
 			}
@@ -258,7 +258,7 @@ func TestRefreshHandler(t *testing.T) {
 		Realm:   "test zone",
 		Key:     key,
 		Timeout: time.Hour,
-		Authenticator: func(userId string, password string) (string, bool) {
+		Authenticator: func(userId string, password string, c *gin.Context) (string, bool) {
 			if userId == "admin" && password == "admin" {
 				return userId, true
 			}
@@ -302,7 +302,7 @@ func TestAuthorizator(t *testing.T) {
 		Realm:   "test zone",
 		Key:     key,
 		Timeout: time.Hour,
-		Authenticator: func(userId string, password string) (string, bool) {
+		Authenticator: func(userId string, password string, c *gin.Context) (string, bool) {
 			if userId == "admin" && password == "admin" {
 				return userId, true
 			}
@@ -355,7 +355,7 @@ func TestClaimsDuringAuthorization(t *testing.T) {
 			// Set custom claim, to be checked in Authorizator method
 			return map[string]interface{}{"testkey": testkey, "exp": 0}
 		},
-		Authenticator: func(userId string, password string) (string, bool) {
+		Authenticator: func(userId string, password string, c *gin.Context) (string, bool) {
 			if userId == "admin" && password == "admin" {
 				return "", true
 			}
@@ -446,7 +446,7 @@ func TestEmptyClaims(t *testing.T) {
 		Realm:   "test zone",
 		Key:     key,
 		Timeout: time.Hour,
-		Authenticator: func(userId string, password string) (string, bool) {
+		Authenticator: func(userId string, password string, c *gin.Context) (string, bool) {
 			if userId == "admin" && password == "admin" {
 				return "", true
 			}
@@ -483,7 +483,7 @@ func TestUnauthorized(t *testing.T) {
 		Realm:   "test zone",
 		Key:     key,
 		Timeout: time.Hour,
-		Authenticator: func(userId string, password string) (string, bool) {
+		Authenticator: func(userId string, password string, c *gin.Context) (string, bool) {
 			if userId == "admin" && password == "admin" {
 				return userId, true
 			}

--- a/example/server.go
+++ b/example/server.go
@@ -29,7 +29,7 @@ func main() {
 		Realm:   "test zone",
 		Key:     []byte("secret key"),
 		Timeout: time.Hour,
-		Authenticator: func(userId string, password string) (string, bool) {
+		Authenticator: func(userId string, password string, c *gin.Context) (string, bool) {
 			if (userId == "admin" && password == "admin") || (userId == "test" && password == "test") {
 				return userId, true
 			}


### PR DESCRIPTION
I think it may be useful / convenient to be aware of the request context to authenticate or to be able to interact with it so that Authorizator can have access to variables set previously in Authenticator. 
