### PR TITLE
errors should always be lower case

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -66,15 +66,15 @@ type Login struct {
 // MiddlewareInit initialize jwt configs.
 func (mw *GinJWTMiddleware) MiddlewareInit() error {
 	if mw.Realm == "" {
-		return errors.New("Realm is required")
+		return errors.New("realm is required")
 	}
 
 	if mw.Authenticator == nil {
-		return errors.New("Authenticator is required")
+		return errors.New("authenticator is required")
 	}
 
 	if mw.Key == nil {
-		return errors.New("Key is required")
+		return errors.New("secret key is required")
 	}
 
 	if mw.SigningAlgorithm == "" {
@@ -268,17 +268,17 @@ func (mw *GinJWTMiddleware) parseToken(c *gin.Context) (*jwt.Token, error) {
 	authHeader := c.Request.Header.Get("Authorization")
 
 	if authHeader == "" {
-		return nil, errors.New("Auth header empty")
+		return nil, errors.New("auth header empty")
 	}
 
 	parts := strings.SplitN(authHeader, " ", 2)
 	if !(len(parts) == 2 && parts[0] == "Bearer") {
-		return nil, errors.New("Invalid auth header")
+		return nil, errors.New("invalid auth header")
 	}
 
 	return jwt.Parse(parts[1], func(token *jwt.Token) (interface{}, error) {
 		if jwt.GetSigningMethod(mw.SigningAlgorithm) != token.Method {
-			return nil, errors.New("Invalid signing algorithm")
+			return nil, errors.New("invalid signing algorithm")
 		}
 
 		return mw.Key, nil

--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -1,10 +1,10 @@
 package jwt
 
 import (
-	"github.com/appleboy/gofight"
 	"github.com/buger/jsonparser"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/appleboy/gofight.v1"
 	"gopkg.in/dgrijalva/jwt-go.v3"
 	"net/http"
 	"net/http/httptest"
@@ -50,7 +50,7 @@ func TestMissingRealm(t *testing.T) {
 	err := authMiddleware.MiddlewareInit()
 
 	assert.Error(t, err)
-	assert.Equal(t, "Realm is required", err.Error())
+	assert.Equal(t, "realm is required", err.Error())
 }
 
 func TestMissingAuthenticator(t *testing.T) {
@@ -65,7 +65,7 @@ func TestMissingAuthenticator(t *testing.T) {
 	err := authMiddleware.MiddlewareInit()
 
 	assert.Error(t, err)
-	assert.Equal(t, "Authenticator is required", err.Error())
+	assert.Equal(t, "authenticator is required", err.Error())
 }
 
 func TestMissingKey(t *testing.T) {
@@ -86,7 +86,7 @@ func TestMissingKey(t *testing.T) {
 	err := authMiddleware.MiddlewareInit()
 
 	assert.Error(t, err)
-	assert.Equal(t, "Key is required", err.Error())
+	assert.Equal(t, "secret key is required", err.Error())
 }
 
 func TestMissingTimeOut(t *testing.T) {


### PR DESCRIPTION
https://github.com/golang/go/wiki/CodeReviewComments#error-strings

Fixed #36

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>