### PR TITLE
Add HTTPStatusMessageFunc to allow users to override status messages

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -81,43 +81,43 @@ type GinJWTMiddleware struct {
 }
 
 var (
-	// Realm name is required
+	// ErrMissingRealm indicates Realm name is required
 	ErrMissingRealm = errors.New("realm is missing")
 
-	// Secret key is required
+	// ErrMissingSecretKey indicates Secret key is required
 	ErrMissingSecretKey = errors.New("secret key is required")
 
-	// HTTP status 403
+	// ErrForbidden when HTTP status 403 is given
 	ErrForbidden = errors.New("you don't have permission to access this resource")
 
-	// Authenticator is required
+	// ErrMissingAuthenticatorFunc indicates Authenticator is required
 	ErrMissingAuthenticatorFunc = errors.New("ginJWTMiddleware.Authenticator func is undefined")
 
-	// Tried to authenticate without username or password
+	// ErrMissingLoginValues indicates a user tried to authenticate without username or password
 	ErrMissingLoginValues = errors.New("missing Username or Password")
 
-	// Authentication failed, could be faulty username or password
+	// ErrFailedAuthentication indicates authentication failed, could be faulty username or password
 	ErrFailedAuthentication = errors.New("incorrect Username or Password")
 
-	// JWT Token failed to create, reason unknown
+	// ErrFailedTokenCreation indicates JWT Token failed to create, reason unknown
 	ErrFailedTokenCreation = errors.New("failed to create JWT Token")
 
-	// JWT token as expired. Can't refresh.
+	// ErrExpiredToken indicates JWT token has expired. Can't refresh.
 	ErrExpiredToken = errors.New("token is expired")
 
-	// If authing with a HTTP header, the Auth header needs to be set
+	// ErrEmptyAuthHeader can be thrown if authing with a HTTP header, the Auth header needs to be set
 	ErrEmptyAuthHeader = errors.New("auth header is empty")
 
-	// Auth header is invalid, could for example have the wrong Realm name
+	// ErrInvalidAuthHeader indicates auth header is invalid, could for example have the wrong Realm name
 	ErrInvalidAuthHeader = errors.New("auth header is invalid")
 
-	// If authing with URL Query, the query token variable is empty
+	// ErrEmptyQueryToken can be thrown if authing with URL Query, the query token variable is empty
 	ErrEmptyQueryToken = errors.New("query token is empty")
 
-	// If authing with a cookie, the token cokie is empty
+	// ErrEmptyCookieToken can be thrown if authing with a cookie, the token cokie is empty
 	ErrEmptyCookieToken = errors.New("cookie token is empty")
 
-	// Signing algorithm needs to be HS256, HS384, or HS512
+	// ErrInvalidSigningAlgorithm indicates signing algorithm is invalid, needs to be HS256, HS384, or HS512
 	ErrInvalidSigningAlgorithm = errors.New("invalid signing algorithm")
 )
 

--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -81,19 +81,44 @@ type GinJWTMiddleware struct {
 }
 
 var (
-	ErrMissingRealm             = errors.New("Realm is missing.")
-	ErrMissingSecretKey         = errors.New("Secret key is required.")
-	ErrForbidden                = errors.New("You don't have permission to access this resource.")
-	ErrMissingAuthenticatorFunc = errors.New("GinJWTMiddleware.Authenticator func is undefined.")
-	ErrMissingLoginValues       = errors.New("Missing Username or Password.")
-	ErrFailedAuthentication     = errors.New("Incorrect Username or Password.")
-	ErrFailedTokenCreation      = errors.New("Failed to create JWT Token.")
-	ErrExpiredToken             = errors.New("Token is expired.")
-	ErrEmptyAuthHeader          = errors.New("Auth header is empty.")
-	ErrInvalidAuthHeader        = errors.New("Auth header is invalid.")
-	ErrEmptyQueryToken          = errors.New("Query token is empty.")
-	ErrEmptyCookieToken         = errors.New("Cookie token is empty.")
-	ErrInvalidSigningAlgorithm  = errors.New("Invalid signing algorithm.")
+	// Realm name is required
+	ErrMissingRealm = errors.New("realm is missing")
+
+	// Secret key is required
+	ErrMissingSecretKey = errors.New("secret key is required")
+
+	// HTTP status 403
+	ErrForbidden = errors.New("you don't have permission to access this resource")
+
+	// Authenticator is required
+	ErrMissingAuthenticatorFunc = errors.New("ginJWTMiddleware.Authenticator func is undefined")
+
+	// Tried to authenticate without username or password
+	ErrMissingLoginValues = errors.New("missing Username or Password")
+
+	// Authentication failed, could be faulty username or password
+	ErrFailedAuthentication = errors.New("incorrect Username or Password")
+
+	// JWT Token failed to create, reason unknown
+	ErrFailedTokenCreation = errors.New("failed to create JWT Token")
+
+	// JWT token as expired. Can't refresh.
+	ErrExpiredToken = errors.New("token is expired")
+
+	// If authing with a HTTP header, the Auth header needs to be set
+	ErrEmptyAuthHeader = errors.New("auth header is empty")
+
+	// Auth header is invalid, could for example have the wrong Realm name
+	ErrInvalidAuthHeader = errors.New("auth header is invalid")
+
+	// If authing with URL Query, the query token variable is empty
+	ErrEmptyQueryToken = errors.New("query token is empty")
+
+	// If authing with a cookie, the token cokie is empty
+	ErrEmptyCookieToken = errors.New("cookie token is empty")
+
+	// Signing algorithm needs to be HS256, HS384, or HS512
+	ErrInvalidSigningAlgorithm = errors.New("invalid signing algorithm")
 )
 
 // Login form structure.


### PR DESCRIPTION
`HTTPStatusMessageFunc` allows users to override HTTP status messages, for example in my use case I have the need to translate the status messages. To make it easer to check the error messages I also moved all errors to their own exported variables, making it easer to check against them outside the middleware.

By default `HTTPStatusMessageFunc` only returns the error as a string, making sure it has the same behavior as today.