### PR TITLE
Add optional arguments to MiddlewareFunc

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -265,7 +265,7 @@ func (mw *GinJWTMiddleware) MiddlewareInit() error {
 }
 
 // MiddlewareFunc makes GinJWTMiddleware implement the Middleware interface.
-func (mw *GinJWTMiddleware) MiddlewareFunc() gin.HandlerFunc {
+func (mw *GinJWTMiddleware) MiddlewareFunc(authArgs ... interface{}) gin.HandlerFunc {
 	if err := mw.MiddlewareInit(); err != nil {
 		return func(c *gin.Context) {
 			mw.unauthorized(c, http.StatusInternalServerError, mw.HTTPStatusMessageFunc(err, nil))
@@ -274,6 +274,7 @@ func (mw *GinJWTMiddleware) MiddlewareFunc() gin.HandlerFunc {
 	}
 
 	return func(c *gin.Context) {
+		c.Set("authArgs", authArgs)
 		mw.middlewareImpl(c)
 		return
 	}


### PR DESCRIPTION
This arguments are passed in order to put some arguments to `context`;
I used this to inform the `Authorizator` that it should validate if the user is Admin or not.
And when i simple want validate if the user is logged in, I do not pass anything through.