### PR TITLE
Update TokenGenerator data from MapClaims to interface

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -467,7 +467,7 @@ func (mw *GinJWTMiddleware) RefreshHandler(c *gin.Context) {
 }
 
 // TokenGenerator method that clients can use to get a jwt token.
-func (mw *GinJWTMiddleware) TokenGenerator(userID string, data MapClaims) (string, time.Time, error) {
+func (mw *GinJWTMiddleware) TokenGenerator(userID string, data interface{}) (string, time.Time, error) {
 	token := jwt.New(jwt.GetSigningMethod(mw.SigningAlgorithm))
 	claims := token.Claims.(jwt.MapClaims)
 


### PR DESCRIPTION
Hi.  
I want to use TokenGenerator func like below but there is a simple issue.
```
func TestAuthMiddleWare(t *testing.T) {
	authMiddleware := &jwt.GinJWTMiddleware{
		Realm: "test Zone",
		Key: []byte("secret key"),
		Timeout: time.Hour,
		MaxRefresh: time.Hour,
		Authenticator: Authenticator,
		Authorizator: Authorizator,
		Unauthorized: Unauthorized,
		PayloadFunc: PayloadFunc,
		TokenLookup: "header:Authorization",
		TokenHeadName: "Bearer",
		TimeFunc: time.Now,
	}
	authMiddleware.MiddlewareInit()

	// ** cannot use User literal (type *User) as type MapClaims **
	token, _, _ := authMiddleware.TokenGenerator("admin", &User{
		UserName: "admin",
		LastName: "Bo-Yi",
		FirstName: "Wu",
	})
}

func PayloadFunc(data interface{}) jwt.MapClaims {
	user := data.(*User)

	return jwt.MapClaims{
		"UserName": user.UserName,
		"FirstName": user.FirstName,
		"LastName": user.LastName,
	}
}
```
As I see it is updated at #115 #118 #126 
I think TokenGenerator should use interface, not MapClaims like Authenticator and LoginHandler
https://github.com/appleboy/gin-jwt/blob/c21115ccebd465511fefed0a0b9f9a4f5a08318d/auth_jwt.go#L360-L375

Can you check it?
