### PR TITLE
Prevent panic when exp claim is empty or a string

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -346,6 +346,16 @@ func (mw *GinJWTMiddleware) middlewareImpl(c *gin.Context) {
 		return
 	}
 
+	if claims["exp"] == nil {
+		mw.unauthorized(c, http.StatusUnauthorized, mw.HTTPStatusMessageFunc(ErrInvalidAuthHeader, c))
+		return
+	}
+
+	if _, ok := claims["exp"].(float64); !ok {
+		mw.unauthorized(c, http.StatusUnauthorized, mw.HTTPStatusMessageFunc(ErrInvalidAuthHeader, c))
+		return
+	}
+
 	if int64(claims["exp"].(float64)) < mw.TimeFunc().Unix() {
 		mw.unauthorized(c, http.StatusUnauthorized, mw.HTTPStatusMessageFunc(ErrExpiredToken, c))
 		return


### PR DESCRIPTION
The "exp" field of the payload is very prone to causing panics. The middleware panics if:

1. The field is missing
2. The field is a string

This PR addresses both issues.