### PR TITLE
Go modules requires the vX suffix for versions higher then 1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/appleboy/gin-jwt
+module github.com/appleboy/gin-jwt/v2
 
 require (
 	github.com/appleboy/gofight v2.0.0+incompatible


### PR DESCRIPTION
https://github.com/golang/go/wiki/Modules:

_If the module is version v2 or higher, the major version of the module must be included as a /vN at the end of the module paths used in go.mod files (e.g., module github.com/my/mod/v2, require github.com/my/mod/v2 v2.0.0) and in the package import path (e.g., import "github.com/my/mod/v2/mypkg")._

Currently after applying v2.6.0 tag in go.mod, it's automatically changed to: github.com/appleboy/gin-jwt v0.0.0-20190409072159-633d983b91f0 