### PR TITLE
Rollback go get url

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ It uses [jwt-go](https://github.com/dgrijalva/jwt-go) to provide a jwt authentic
 Download and install it:
 
 ```sh
-$ go get github.com/appleboy/gin-jwt/v2
+$ go get github.com/appleboy/gin-jwt
 ```
 
 Import it in your code:
 
 ```go
-import "github.com/appleboy/gin-jwt/v2"
+import "github.com/appleboy/gin-jwt"
 ```
 
 ## Example
@@ -40,7 +40,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/appleboy/gin-jwt/v2"
+	"github.com/appleboy/gin-jwt"
 	"github.com/gin-gonic/gin"
 )
 


### PR DESCRIPTION
go get github.com/appleboy/gin-jwt/v2 breaks but removing /v2 does get the program. Other people are having troubles  because of this and this should be fixed untill v2 is the real path.