### PR TITLE
Add LogoutHandler and LogoutResponse to allow user to remove jwt cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Www-Authenticate: JWT realm=test zone
 ```
 
 ### Cookie Token
-Use these options for setting the JWT in a cookie. See the Mozilla [documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Secure_and_HttpOnly_cookies) for more information on these options. 
+Use these options for setting the JWT in a cookie. See the Mozilla [documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Secure_and_HttpOnly_cookies) for more information on these options.
 
 ```go
 	SendCookie:       true,
@@ -275,13 +275,15 @@ Use these options for setting the JWT in a cookie. See the Mozilla [documentatio
 	TokenLookup:      "cookie:token",
 ```
 
-### Login Flow 
-1. Authenticator: handles the login logic. On success LoginResponse is called, on failure Unauthorized is called. 
+Adding a route to the `LogoutHandler` route will the deletion of the auth cookie, effectively logging the user out. The `LoginResponse` object can optionally be set to customize the response of this endpoint.
+
+### Login Flow
+1. Authenticator: handles the login logic. On success LoginResponse is called, on failure Unauthorized is called.
 2. LoginResponse: optional, allows setting a custom response such as a redirect.
 
 
-### JWT Flow 
-1. PayloadFunc: maps the claims in the JWT. 
-2. IdentityHandler: extracts identity from claims. 
+### JWT Flow
+1. PayloadFunc: maps the claims in the JWT.
+2. IdentityHandler: extracts identity from claims.
 3. Authorizator: receives identity and handles authorization logic.
 4. Unauthorized: handles unauthorized logic.

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,7 @@ github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726/go.mod h1:3yhqj7WBBf
 github.com/siddontang/ledisdb v0.0.0-20181029004158-becf5f38d373/go.mod h1:mF1DpOSOUiJRMR+FDqaqu3EBqrybQtrDDszLUZ6oxPg=
 github.com/siddontang/rdb v0.0.0-20150307021120-fc89ed2e418d/go.mod h1:AMEsy7v5z92TR1JKMkLLoaOQk++LVnOKL3ScbJ8GNGA=
 github.com/ssdb/gossdb v0.0.0-20180723034631-88f6b59b84ec/go.mod h1:QBvMkMya+gXctz3kmljlUCu/yB3GZ6oee+dUozsezQE=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
Adds a basic `LogoutHandler` (with customizable `LogoutResponse` object like `LoginResponse`) to the middleware allowing users to add a route to have the jwt cookie deleted using the same settings as were used to create the cookie.