### PR TITLE
Implement KeyFunc

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -32,6 +32,10 @@ type GinJWTMiddleware struct {
 	// Secret key used for signing. Required.
 	Key []byte
 
+	// Callback to retrieve key used for signing. Setting KeyFunc will bypass
+	// all other key settings
+	KeyFunc func(token *jwt.Token) (interface{}, error)
+
 	// Duration that a jwt token is valid. Optional, defaults to one hour.
 	Timeout time.Duration
 
@@ -337,6 +341,11 @@ func (mw *GinJWTMiddleware) MiddlewareInit() error {
 
 	if mw.CookieName == "" {
 		mw.CookieName = "jwt"
+	}
+
+	// bypass other key settings if KeyFunc is set
+	if mw.KeyFunc != nil {
+		return nil
 	}
 
 	if mw.usingPublicKeyAlgo() {
@@ -674,6 +683,10 @@ func (mw *GinJWTMiddleware) ParseToken(c *gin.Context) (*jwt.Token, error) {
 		return nil, err
 	}
 
+	if mw.KeyFunc != nil {
+		return jwt.Parse(token, mw.KeyFunc)
+	}
+
 	return jwt.Parse(token, func(t *jwt.Token) (interface{}, error) {
 		if jwt.GetSigningMethod(mw.SigningAlgorithm) != t.Method {
 			return nil, ErrInvalidSigningAlgorithm
@@ -691,6 +704,11 @@ func (mw *GinJWTMiddleware) ParseToken(c *gin.Context) (*jwt.Token, error) {
 
 // ParseTokenString parse jwt token string
 func (mw *GinJWTMiddleware) ParseTokenString(token string) (*jwt.Token, error) {
+
+	if mw.KeyFunc != nil {
+		return jwt.Parse(token, mw.KeyFunc)
+	}
+
 	return jwt.Parse(token, func(t *jwt.Token) (interface{}, error) {
 		if jwt.GetSigningMethod(mw.SigningAlgorithm) != t.Method {
 			return nil, ErrInvalidSigningAlgorithm

--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -61,6 +61,14 @@ func makeTokenString(SigningAlgorithm string, username string) string {
 	return tokenString
 }
 
+func keyFunc(token *jwt.Token) (interface{}, error) {
+	cert, err := ioutil.ReadFile("testdata/jwtRS256.key.pub")
+	if err != nil {
+		return nil, err
+	}
+	return jwt.ParseRSAPublicKeyFromPEM(cert)
+}
+
 func TestMissingKey(t *testing.T) {
 
 	_, err := New(&GinJWTMiddleware{
@@ -356,6 +364,58 @@ func TestParseTokenRS256(t *testing.T) {
 		PrivKeyFile:      "testdata/jwtRS256.key",
 		PubKeyFile:       "testdata/jwtRS256.key.pub",
 		Authenticator:    defaultAuthenticator,
+	})
+
+	handler := ginHandler(authMiddleware)
+
+	r := gofight.New()
+
+	r.GET("/auth/hello").
+		SetHeader(gofight.H{
+			"Authorization": "",
+		}).
+		Run(handler, func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
+			assert.Equal(t, http.StatusUnauthorized, r.Code)
+		})
+
+	r.GET("/auth/hello").
+		SetHeader(gofight.H{
+			"Authorization": "Test 1234",
+		}).
+		Run(handler, func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
+			assert.Equal(t, http.StatusUnauthorized, r.Code)
+		})
+
+	r.GET("/auth/hello").
+		SetHeader(gofight.H{
+			"Authorization": "Bearer " + makeTokenString("HS384", "admin"),
+		}).
+		Run(handler, func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
+			assert.Equal(t, http.StatusUnauthorized, r.Code)
+		})
+
+	r.GET("/auth/hello").
+		SetHeader(gofight.H{
+			"Authorization": "Bearer " + makeTokenString("RS256", "admin"),
+		}).
+		Run(handler, func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
+			assert.Equal(t, http.StatusOK, r.Code)
+		})
+}
+
+func TestParseTokenKeyFunc(t *testing.T) {
+	// the middleware to test
+	authMiddleware, _ := New(&GinJWTMiddleware{
+		Realm:         "test zone",
+		KeyFunc:       keyFunc,
+		Timeout:       time.Hour,
+		MaxRefresh:    time.Hour * 24,
+		Authenticator: defaultAuthenticator,
+		// make sure it skips these settings
+		Key:              []byte(""),
+		SigningAlgorithm: "RS256",
+		PrivKeyFile:      "",
+		PubKeyFile:       "",
 	})
 
 	handler := ginHandler(authMiddleware)


### PR DESCRIPTION
This PR should resolve https://github.com/appleboy/gin-jwt/issues/234

I implemented a `KeyFunc` option which will bypass other key options (`Key`, `PublicKey`, `PrivateKey`). This allows the developer to write their own validation logic by providing a callback function.

Additionally I added a `TestParseTokenKeyFunc` test to make sure the callback is being used correctly.