### PR TITLE
developer need call MiddlewareInit by themself 

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,13 @@ func main() {
 	if err != nil {
 		log.Fatal("JWT Error:" + err.Error())
 	}
-
+  
+  errInit := authMiddleware.MiddlewareInit()
+  
+	if errInit != nil {
+		log.Fatal("authMiddleware.MiddlewareInit() Error:" + errInit.Error())
+	}
+  
 	r.POST("/login", authMiddleware.LoginHandler)
 
 	r.NoRoute(authMiddleware.MiddlewareFunc(), func(c *gin.Context) {

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/appleboy/gin-jwt/v2"
+	jwt "github.com/appleboy/gin-jwt/v2"
 	"github.com/gin-gonic/gin"
 )
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ func main() {
 		log.Fatal("JWT Error:" + err.Error())
 	}
   
-  errInit := authMiddleware.MiddlewareInit()
+	errInit := authMiddleware.MiddlewareInit()
   
 	if errInit != nil {
 		log.Fatal("authMiddleware.MiddlewareInit() Error:" + errInit.Error())

--- a/README.md
+++ b/README.md
@@ -165,13 +165,13 @@ func main() {
 	if err != nil {
 		log.Fatal("JWT Error:" + err.Error())
 	}
-  
+
 	errInit := authMiddleware.MiddlewareInit()
-  
+
 	if errInit != nil {
 		log.Fatal("authMiddleware.MiddlewareInit() Error:" + errInit.Error())
 	}
-  
+
 	r.POST("/login", authMiddleware.LoginHandler)
 
 	r.NoRoute(authMiddleware.MiddlewareFunc(), func(c *gin.Context) {

--- a/_example/basic/server.go
+++ b/_example/basic/server.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/appleboy/gin-jwt/v2"
+	jwt "github.com/appleboy/gin-jwt/v2"
 	"github.com/gin-gonic/gin"
 )
 
@@ -117,6 +117,12 @@ func main() {
 
 	if err != nil {
 		log.Fatal("JWT Error:" + err.Error())
+	}
+
+	errInit := authMiddleware.MiddlewareInit()
+
+	if errInit != nil {
+		log.Fatal("authMiddleware.MiddlewareInit() Error:" + errInit.Error())
 	}
 
 	r.POST("/login", authMiddleware.LoginHandler)


### PR DESCRIPTION

This PR should resolve #255 
after defind authMiddleware ,developer need call MiddlewareInit by themself  

we should add this code into  ```Example```

```go
    errInit := authMiddleware.MiddlewareInit()
    if errInit != nil {
        log.Fatal("authMiddleware.MiddlewareInit() Error:" + errInit.Error())
    }
```