### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Use these options for setting the JWT in a cookie. See the Mozilla [documentatio
 
 	This is a provided function to be called on any refresh token endpoint. If the token passed in is was issued within the `MaxRefreshTime` time frame, then this handler will create/set a new token similar to the `LoginHandler`, and pass this token into `RefreshResponse`
 
-2. OPTIONAL: `RefreshResposne`:
+2. OPTIONAL: `RefreshResponse`:
 
 	This should likely return a JSON of the token back to the user, similar to `LoginResponse`
 


### PR DESCRIPTION
Change `RefreshResposne` to `RefreshResponse`.