### PR TITLE
Fixing the build after upgrade to golang-jwt

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -106,7 +106,7 @@ type GinJWTMiddleware struct {
 
 	// Public key file for asymmetric algorithms
 	PubKeyFile string
-	
+
 	// Private key passphrase
 	PrivateKeyPassphrase string
 
@@ -169,7 +169,7 @@ var (
 	ErrFailedTokenCreation = errors.New("failed to create JWT Token")
 
 	// ErrExpiredToken indicates JWT token has expired. Can't refresh.
-	ErrExpiredToken = errors.New("token is expired")
+	ErrExpiredToken = errors.New("token is expired") // in practice, this is generated from the jwt library not by us
 
 	// ErrEmptyAuthHeader can be thrown if authing with a HTTP header, the Auth header needs to be set
 	ErrEmptyAuthHeader = errors.New("auth header is empty")
@@ -243,7 +243,7 @@ func (mw *GinJWTMiddleware) privateKey() error {
 		}
 		keyData = filecontent
 	}
-	
+
 	if mw.PrivateKeyPassphrase != "" {
 		key, err := jwt.ParseRSAPrivateKeyFromPEMWithPassword(keyData, mw.PrivateKeyPassphrase)
 		if err != nil {
@@ -252,7 +252,6 @@ func (mw *GinJWTMiddleware) privateKey() error {
 		mw.privKey = key
 		return nil
 	}
-
 
 	key, err := jwt.ParseRSAPrivateKeyFromPEM(keyData)
 	if err != nil {

--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -1155,7 +1155,7 @@ func TestExpiredField(t *testing.T) {
 		})
 
 	// wrong format
-	claims["exp"] = "test"
+	claims["exp"] = "wrongFormatForExpiryIgnoredByJwtLibrary"
 	tokenString, _ = token.SignedString(key)
 
 	r.GET("/auth/hello").
@@ -1165,8 +1165,8 @@ func TestExpiredField(t *testing.T) {
 		Run(handler, func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
 			message := gjson.Get(r.Body.String(), "message")
 
-			assert.Equal(t, ErrWrongFormatOfExp.Error(), message.String())
-			assert.Equal(t, http.StatusBadRequest, r.Code)
+			assert.Equal(t, ErrExpiredToken.Error(), strings.ToLower(message.String()))
+			assert.Equal(t, http.StatusUnauthorized, r.Code)
 		})
 }
 


### PR DESCRIPTION
The new golang-jwt library manages internally the validation of the exp field, and thus the behavior in case of malformed exp falls back to the expired token case.