### PR TITLE
Add an option to parse token from POST form data.

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -711,6 +711,16 @@ func (mw *GinJWTMiddleware) jwtFromParam(c *gin.Context, key string) (string, er
 	return token, nil
 }
 
+func (mw *GinJWTMiddleware) jwtFromForm(c *gin.Context, key string) (string, error) {
+	token := c.PostForm(key)
+
+	if token == "" {
+		return "", ErrEmptyParamToken
+	}
+
+	return token, nil
+}
+
 // ParseToken parse jwt token from gin context
 func (mw *GinJWTMiddleware) ParseToken(c *gin.Context) (*jwt.Token, error) {
 	var token string
@@ -733,6 +743,8 @@ func (mw *GinJWTMiddleware) ParseToken(c *gin.Context) (*jwt.Token, error) {
 			token, err = mw.jwtFromCookie(c, v)
 		case "param":
 			token, err = mw.jwtFromParam(c, v)
+		case "form":
+			token, err = mw.jwtFromForm(c, v)
 		}
 	}
 


### PR DESCRIPTION
As mentioned in [Issue 292](https://github.com/appleboy/gin-jwt/issues/292), we all participated in the training camp organized by ByteDance. They recommended this lightweight middleware for our project. The job assigned to us needs to parse the token from the POST form data, which have not been supported by this middleware. So I wish to add a parsing option to support this and it works fine in my own project.