### PR TITLE
fix(timezone): remove stray `UTC()` call

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -669,7 +669,7 @@ func (mw *GinJWTMiddleware) TokenGenerator(data interface{}) (string, time.Time,
 		}
 	}
 
-	expire := mw.TimeFunc().UTC().Add(mw.Timeout)
+	expire := mw.TimeFunc().Add(mw.Timeout)
 	claims["exp"] = expire.Unix()
 	claims["orig_iat"] = mw.TimeFunc().Unix()
 	tokenString, err := mw.signedString(token)


### PR DESCRIPTION
Only in `TokenGenerator` `mw.TimeFunc().UTC()` is called (all other places do not call `UTC`), making the result inconsistent with the result of other functions.