### PR TITLE
Remove typo server.go

### DIFF
--- a/_example/basic/server.go
+++ b/_example/basic/server.go
@@ -12,7 +12,7 @@ import (
 
 type login struct {
 	Username string `form:"username" json:"username" binding:"required"`
-	Password string `form:"password" json:"password" binding:"required"`ach
+	Password string `form:"password" json:"password" binding:"required"`
 }
 
 var (


### PR DESCRIPTION
Server Example has a typo that causes an error.