### PR TITLE
refactor: adopt jwt.MapClaims to replace custom MapClaims type

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -14,10 +14,6 @@ import (
 	"github.com/youmark/pkcs8"
 )
 
-// MapClaims type that uses the map[string]interface{} for JSON decoding
-// This is the default claims type if you don't supply one
-type MapClaims map[string]interface{}
-
 // GinJWTMiddleware provides a Json-Web-Token authentication implementation. On failure, a 401 HTTP response
 // is returned. On success, the wrapped middleware is called, and the userID is made available as
 // c.Get("userID").(string).
@@ -65,7 +61,7 @@ type GinJWTMiddleware struct {
 	// Note that the payload is not encrypted.
 	// The attributes mentioned on jwt.io can't be used as keys for the map.
 	// Optional, by default no additional data will be set.
-	PayloadFunc func(data interface{}) MapClaims
+	PayloadFunc func(data interface{}) jwt.MapClaims
 
 	// User can define own Unauthorized func.
 	Unauthorized func(c *gin.Context, code int, message string)
@@ -487,7 +483,7 @@ func (mw *GinJWTMiddleware) middlewareImpl(c *gin.Context) {
 }
 
 // GetClaimsFromJWT get claims from JWT token
-func (mw *GinJWTMiddleware) GetClaimsFromJWT(c *gin.Context) (MapClaims, error) {
+func (mw *GinJWTMiddleware) GetClaimsFromJWT(c *gin.Context) (jwt.MapClaims, error) {
 	token, err := mw.ParseToken(c)
 	if err != nil {
 		return nil, err
@@ -499,7 +495,7 @@ func (mw *GinJWTMiddleware) GetClaimsFromJWT(c *gin.Context) (MapClaims, error) 
 		}
 	}
 
-	claims := MapClaims{}
+	claims := jwt.MapClaims{}
 	for key, value := range token.Claims.(jwt.MapClaims) {
 		claims[key] = value
 	}
@@ -801,22 +797,22 @@ func (mw *GinJWTMiddleware) unauthorized(c *gin.Context, code int, message strin
 }
 
 // ExtractClaims help to extract the JWT claims
-func ExtractClaims(c *gin.Context) MapClaims {
+func ExtractClaims(c *gin.Context) jwt.MapClaims {
 	claims, exists := c.Get("JWT_PAYLOAD")
 	if !exists {
-		return make(MapClaims)
+		return make(jwt.MapClaims)
 	}
 
-	return claims.(MapClaims)
+	return claims.(jwt.MapClaims)
 }
 
 // ExtractClaimsFromToken help to extract the JWT claims from token
-func ExtractClaimsFromToken(token *jwt.Token) MapClaims {
+func ExtractClaimsFromToken(token *jwt.Token) jwt.MapClaims {
 	if token == nil {
-		return make(MapClaims)
+		return make(jwt.MapClaims)
 	}
 
-	claims := MapClaims{}
+	claims := jwt.MapClaims{}
 	for key, value := range token.Claims.(jwt.MapClaims) {
 		claims[key] = value
 	}

--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -235,9 +235,9 @@ func TestLoginHandler(t *testing.T) {
 	authMiddleware, err := New(&GinJWTMiddleware{
 		Realm: "test zone",
 		Key:   key,
-		PayloadFunc: func(data interface{}) MapClaims {
+		PayloadFunc: func(data interface{}) jwt.MapClaims {
 			// Set custom claim, to be checked in Authorizator method
-			return MapClaims{"testkey": "testval", "exp": 0}
+			return jwt.MapClaims{"testkey": "testval", "exp": 0}
 		},
 		Authenticator: func(c *gin.Context) (interface{}, error) {
 			var loginVals Login
@@ -699,13 +699,13 @@ func TestClaimsDuringAuthorization(t *testing.T) {
 		Key:        key,
 		Timeout:    time.Hour,
 		MaxRefresh: time.Hour * 24,
-		PayloadFunc: func(data interface{}) MapClaims {
-			if v, ok := data.(MapClaims); ok {
+		PayloadFunc: func(data interface{}) jwt.MapClaims {
+			if v, ok := data.(jwt.MapClaims); ok {
 				return v
 			}
 
 			if reflect.TypeOf(data).String() != "string" {
-				return MapClaims{}
+				return jwt.MapClaims{}
 			}
 
 			var testkey string
@@ -718,7 +718,7 @@ func TestClaimsDuringAuthorization(t *testing.T) {
 				testkey = ""
 			}
 			// Set custom claim, to be checked in Authorizator method
-			return MapClaims{"identity": data.(string), "testkey": testkey, "exp": 0}
+			return jwt.MapClaims{"identity": data.(string), "testkey": testkey, "exp": 0}
 		},
 		Authenticator: func(c *gin.Context) (interface{}, error) {
 			var loginVals Login
@@ -762,7 +762,7 @@ func TestClaimsDuringAuthorization(t *testing.T) {
 	r := gofight.New()
 	handler := ginHandler(authMiddleware)
 
-	userToken, _, _ := authMiddleware.TokenGenerator(MapClaims{
+	userToken, _, _ := authMiddleware.TokenGenerator(jwt.MapClaims{
 		"identity": "administrator",
 	})
 
@@ -813,12 +813,12 @@ func TestClaimsDuringAuthorization(t *testing.T) {
 		})
 }
 
-func ConvertClaims(claims MapClaims) map[string]interface{} {
+func ConvertClaims(claims jwt.MapClaims) map[string]interface{} {
 	return map[string]interface{}{}
 }
 
 func TestEmptyClaims(t *testing.T) {
-	var jwtClaims MapClaims
+	var jwtClaims jwt.MapClaims
 
 	// the middleware to test
 	authMiddleware, _ := New(&GinJWTMiddleware{
@@ -905,7 +905,7 @@ func TestTokenExpire(t *testing.T) {
 
 	r := gofight.New()
 
-	userToken, _, _ := authMiddleware.TokenGenerator(MapClaims{
+	userToken, _, _ := authMiddleware.TokenGenerator(jwt.MapClaims{
 		"identity": "admin",
 	})
 
@@ -935,7 +935,7 @@ func TestTokenFromQueryString(t *testing.T) {
 
 	r := gofight.New()
 
-	userToken, _, _ := authMiddleware.TokenGenerator(MapClaims{
+	userToken, _, _ := authMiddleware.TokenGenerator(jwt.MapClaims{
 		"identity": "admin",
 	})
 
@@ -973,7 +973,7 @@ func TestTokenFromParamPath(t *testing.T) {
 
 	r := gofight.New()
 
-	userToken, _, _ := authMiddleware.TokenGenerator(MapClaims{
+	userToken, _, _ := authMiddleware.TokenGenerator(jwt.MapClaims{
 		"identity": "admin",
 	})
 
@@ -1008,7 +1008,7 @@ func TestTokenFromCookieString(t *testing.T) {
 
 	r := gofight.New()
 
-	userToken, _, _ := authMiddleware.TokenGenerator(MapClaims{
+	userToken, _, _ := authMiddleware.TokenGenerator(jwt.MapClaims{
 		"identity": "admin",
 	})
 
@@ -1253,8 +1253,8 @@ func TestCheckTokenString(t *testing.T) {
 		Unauthorized: func(c *gin.Context, code int, message string) {
 			c.String(code, message)
 		},
-		PayloadFunc: func(data interface{}) MapClaims {
-			if v, ok := data.(MapClaims); ok {
+		PayloadFunc: func(data interface{}) jwt.MapClaims {
+			if v, ok := data.(jwt.MapClaims); ok {
 				return v
 			}
 
@@ -1266,7 +1266,7 @@ func TestCheckTokenString(t *testing.T) {
 
 	r := gofight.New()
 
-	userToken, _, _ := authMiddleware.TokenGenerator(MapClaims{
+	userToken, _, _ := authMiddleware.TokenGenerator(jwt.MapClaims{
 		"identity": "admin",
 	})
 
@@ -1295,7 +1295,7 @@ func TestCheckTokenString(t *testing.T) {
 
 	_, err = authMiddleware.ParseTokenString(userToken)
 	assert.Error(t, err)
-	assert.Equal(t, MapClaims{}, ExtractClaimsFromToken(nil))
+	assert.Equal(t, jwt.MapClaims{}, ExtractClaimsFromToken(nil))
 }
 
 func TestLogout(t *testing.T) {


### PR DESCRIPTION
- Remove the custom `MapClaims` type definition
- Replace `MapClaims` with `jwt.MapClaims` in `PayloadFunc`, `GetClaimsFromJWT`, `ExtractClaims`, and `ExtractClaimsFromToken` functions
- Update test cases to use `jwt.MapClaims` instead of the custom `MapClaims`
- Update `ConvertClaims` function to accept `jwt.MapClaims`

fix #341 