### PR TITLE
Expose jwt-go MapClaims through gin-jwt.

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -14,6 +14,8 @@ import (
 	"github.com/youmark/pkcs8"
 )
 
+type MapClaims jwt.MapClaims
+
 // GinJWTMiddleware provides a Json-Web-Token authentication implementation. On failure, a 401 HTTP response
 // is returned. On success, the wrapped middleware is called, and the userID is made available as
 // c.Get("userID").(string).
@@ -61,7 +63,7 @@ type GinJWTMiddleware struct {
 	// Note that the payload is not encrypted.
 	// The attributes mentioned on jwt.io can't be used as keys for the map.
 	// Optional, by default no additional data will be set.
-	PayloadFunc func(data interface{}) jwt.MapClaims
+	PayloadFunc func(data interface{}) MapClaims
 
 	// User can define own Unauthorized func.
 	Unauthorized func(c *gin.Context, code int, message string)
@@ -483,7 +485,7 @@ func (mw *GinJWTMiddleware) middlewareImpl(c *gin.Context) {
 }
 
 // GetClaimsFromJWT get claims from JWT token
-func (mw *GinJWTMiddleware) GetClaimsFromJWT(c *gin.Context) (jwt.MapClaims, error) {
+func (mw *GinJWTMiddleware) GetClaimsFromJWT(c *gin.Context) (MapClaims, error) {
 	token, err := mw.ParseToken(c)
 	if err != nil {
 		return nil, err
@@ -495,7 +497,7 @@ func (mw *GinJWTMiddleware) GetClaimsFromJWT(c *gin.Context) (jwt.MapClaims, err
 		}
 	}
 
-	claims := jwt.MapClaims{}
+	claims := MapClaims{}
 	for key, value := range token.Claims.(jwt.MapClaims) {
 		claims[key] = value
 	}
@@ -797,22 +799,22 @@ func (mw *GinJWTMiddleware) unauthorized(c *gin.Context, code int, message strin
 }
 
 // ExtractClaims help to extract the JWT claims
-func ExtractClaims(c *gin.Context) jwt.MapClaims {
+func ExtractClaims(c *gin.Context) MapClaims {
 	claims, exists := c.Get("JWT_PAYLOAD")
 	if !exists {
-		return make(jwt.MapClaims)
+		return make(MapClaims)
 	}
 
-	return claims.(jwt.MapClaims)
+	return claims.(MapClaims)
 }
 
 // ExtractClaimsFromToken help to extract the JWT claims from token
-func ExtractClaimsFromToken(token *jwt.Token) jwt.MapClaims {
+func ExtractClaimsFromToken(token *jwt.Token) MapClaims {
 	if token == nil {
-		return make(jwt.MapClaims)
+		return make(MapClaims)
 	}
 
-	claims := jwt.MapClaims{}
+	claims := MapClaims{}
 	for key, value := range token.Claims.(jwt.MapClaims) {
 		claims[key] = value
 	}

--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -235,9 +235,9 @@ func TestLoginHandler(t *testing.T) {
 	authMiddleware, err := New(&GinJWTMiddleware{
 		Realm: "test zone",
 		Key:   key,
-		PayloadFunc: func(data interface{}) jwt.MapClaims {
+		PayloadFunc: func(data interface{}) MapClaims {
 			// Set custom claim, to be checked in Authorizator method
-			return jwt.MapClaims{"testkey": "testval", "exp": 0}
+			return MapClaims{"testkey": "testval", "exp": 0}
 		},
 		Authenticator: func(c *gin.Context) (interface{}, error) {
 			var loginVals Login
@@ -699,13 +699,13 @@ func TestClaimsDuringAuthorization(t *testing.T) {
 		Key:        key,
 		Timeout:    time.Hour,
 		MaxRefresh: time.Hour * 24,
-		PayloadFunc: func(data interface{}) jwt.MapClaims {
-			if v, ok := data.(jwt.MapClaims); ok {
+		PayloadFunc: func(data interface{}) MapClaims {
+			if v, ok := data.(MapClaims); ok {
 				return v
 			}
 
 			if reflect.TypeOf(data).String() != "string" {
-				return jwt.MapClaims{}
+				return MapClaims{}
 			}
 
 			var testkey string
@@ -718,7 +718,7 @@ func TestClaimsDuringAuthorization(t *testing.T) {
 				testkey = ""
 			}
 			// Set custom claim, to be checked in Authorizator method
-			return jwt.MapClaims{"identity": data.(string), "testkey": testkey, "exp": 0}
+			return MapClaims{"identity": data.(string), "testkey": testkey, "exp": 0}
 		},
 		Authenticator: func(c *gin.Context) (interface{}, error) {
 			var loginVals Login
@@ -813,7 +813,7 @@ func TestClaimsDuringAuthorization(t *testing.T) {
 		})
 }
 
-func ConvertClaims(claims jwt.MapClaims) map[string]interface{} {
+func ConvertClaims(claims MapClaims) map[string]interface{} {
 	return map[string]interface{}{}
 }
 
@@ -1253,8 +1253,8 @@ func TestCheckTokenString(t *testing.T) {
 		Unauthorized: func(c *gin.Context, code int, message string) {
 			c.String(code, message)
 		},
-		PayloadFunc: func(data interface{}) jwt.MapClaims {
-			if v, ok := data.(jwt.MapClaims); ok {
+		PayloadFunc: func(data interface{}) MapClaims {
+			if v, ok := data.(MapClaims); ok {
 				return v
 			}
 


### PR DESCRIPTION
This pull request updates the `MapClaims` struct to be an alias of the golang-jwt library's MapClaims instead of requiring all the downstream functions to use the `golang-jwt` library's struct. 

This helps a lot with breaking changes (such as the one introduced in the last tag) because it means that the function inputs can be consistent, and it prevents anyone who uses `MapClaims` in upstream code from needing to import `golang-jwt` in any of their packages. This is important because requiring users to import golang-jwt directly can cause version mismatches when trying to manage dependencies.