### PR TITLE
feat: adopt OAuth2-style token fields in authentication responses

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -357,9 +357,11 @@ func (mw *GinJWTMiddleware) MiddlewareInit() error {
 	if mw.LoginResponse == nil {
 		mw.LoginResponse = func(c *gin.Context, code int, token string, expire time.Time) {
 			c.JSON(http.StatusOK, gin.H{
-				"code":   http.StatusOK,
-				"token":  token,
-				"expire": expire.Format(time.RFC3339),
+				"access_token":  token,
+				"token_type":    "Bearer",
+				"expires_in":    int(time.Until(expire).Seconds()),
+				"refresh_token": "",
+				"scope":         "create",
 			})
 		}
 	}
@@ -375,9 +377,11 @@ func (mw *GinJWTMiddleware) MiddlewareInit() error {
 	if mw.RefreshResponse == nil {
 		mw.RefreshResponse = func(c *gin.Context, code int, token string, expire time.Time) {
 			c.JSON(http.StatusOK, gin.H{
-				"code":   http.StatusOK,
-				"token":  token,
-				"expire": expire.Format(time.RFC3339),
+				"access_token":  token,
+				"token_type":    "Bearer",
+				"expires_in":    int(time.Until(expire).Seconds()),
+				"refresh_token": "",
+				"scope":         "create",
 			})
 		}
 	}

--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -356,11 +356,19 @@ func (mw *GinJWTMiddleware) MiddlewareInit() error {
 
 	if mw.LoginResponse == nil {
 		mw.LoginResponse = func(c *gin.Context, code int, token string, expire time.Time) {
+			refreshToken, _, err := mw.RefreshToken(c)
+			if err != nil {
+				c.JSON(http.StatusUnauthorized, gin.H{
+					"code":    http.StatusUnauthorized,
+					"message": mw.HTTPStatusMessageFunc(err, c),
+				})
+				return
+			}
 			c.JSON(http.StatusOK, gin.H{
 				"access_token":  token,
 				"token_type":    "Bearer",
 				"expires_in":    int(time.Until(expire).Seconds()),
-				"refresh_token": "",
+				"refresh_token": refreshToken,
 				"scope":         "create",
 			})
 		}
@@ -376,11 +384,19 @@ func (mw *GinJWTMiddleware) MiddlewareInit() error {
 
 	if mw.RefreshResponse == nil {
 		mw.RefreshResponse = func(c *gin.Context, code int, token string, expire time.Time) {
+			refreshToken, _, err := mw.RefreshToken(c)
+			if err != nil {
+				c.JSON(http.StatusUnauthorized, gin.H{
+					"code":    http.StatusUnauthorized,
+					"message": mw.HTTPStatusMessageFunc(err, c),
+				})
+				return
+			}
 			c.JSON(http.StatusOK, gin.H{
 				"access_token":  token,
 				"token_type":    "Bearer",
 				"expires_in":    int(time.Until(expire).Seconds()),
-				"refresh_token": "",
+				"refresh_token": refreshToken,
 				"scope":         "create",
 			})
 		}

--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -527,9 +527,11 @@ func TestRefreshHandlerRS256(t *testing.T) {
 		Run(handler, func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
 			message := gjson.Get(r.Body.String(), "message")
 			cookie := gjson.Get(r.Body.String(), "cookie")
+			refreshToken := gjson.Get(r.Body.String(), "refresh_token")
 			assert.Equal(t, "refresh successfully", message.String())
 			assert.Equal(t, http.StatusOK, r.Code)
 			assert.Equal(t, makeTokenString("RS256", "admin"), cookie.String())
+			assert.NotEmpty(t, refreshToken.String(), "refresh_token should not be empty")
 		})
 }
 


### PR DESCRIPTION
- Replace token response fields with OAuth2-style fields: access_token, token_type, expires_in, refresh_token, and scope
- Add a test assertion to verify that refresh_token is present and not empty in the response

fix https://github.com/appleboy/gin-jwt/issues/346

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login and token refresh responses now include updated JSON fields: "access_token", "token_type", "expires_in", "refresh_token", and "scope" for improved clarity and compatibility.
  * Enhanced error handling returns a 401 Unauthorized response if refresh token retrieval fails.

* **Bug Fixes**
  * Token refresh responses now reliably include a non-empty "refresh_token" field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->