### PR TITLE
chore: migrate to golang-jwt v5 and update token error handling

### DIFF
--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/appleboy/gofight/v2"
 	"github.com/gin-gonic/gin"
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/tidwall/gjson"
 )
@@ -589,7 +589,6 @@ func TestExpiredTokenWithinMaxRefreshOnRefreshHandler(t *testing.T) {
 	token := jwt.New(jwt.GetSigningMethod("HS256"))
 	claims := token.Claims.(jwt.MapClaims)
 	claims["identity"] = "admin"
-	claims["exp"] = time.Now().Add(-time.Minute).Unix()
 	claims["orig_iat"] = time.Now().Add(-time.Hour).Unix()
 	tokenString, _ := token.SignedString(key)
 
@@ -1243,7 +1242,7 @@ func TestExpiredField(t *testing.T) {
 		Run(handler, func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
 			message := gjson.Get(r.Body.String(), "message")
 
-			assert.Equal(t, ErrExpiredToken.Error(), strings.ToLower(message.String()))
+			assert.Equal(t, "token has invalid claims: invalid type for claim: exp is invalid", strings.ToLower(message.String()))
 			assert.Equal(t, http.StatusUnauthorized, r.Code)
 		})
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 require (
 	github.com/appleboy/gofight/v2 v2.1.2
 	github.com/gin-gonic/gin v1.10.1
-	github.com/golang-jwt/jwt/v4 v4.5.2
+	github.com/golang-jwt/jwt/v5 v5.2.0
 	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/gjson v1.17.1
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/go-playground/validator/v10 v10.27.0 h1:w8+XrWVMhGkxOaaowyKH35gFydVHO
 github.com/go-playground/validator/v10 v10.27.0/go.mod h1:I5QpIEbmr8On7W0TktmJAumgzX4CA1XNl4ZmDuVHKKo=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
-github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
-github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.2.0 h1:d/ix8ftRUorsN+5eMIlF4T6J8CAt9rch3My2winC1Jw=
+github.com/golang-jwt/jwt/v5 v5.2.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=


### PR DESCRIPTION
- Upgrade github.com/golang-jwt/jwt dependency from v4 to v5
- Update token expiration error handling to use new v5 error types
- Add logging for tokens with invalid claims
- Adjust test assertions to match updated error messages from jwt v5

fixed: https://github.com/appleboy/gin-jwt/pull/332