### PR TITLE
refactor: refactor codebase to use jwt.MapClaims directly

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -13,8 +13,6 @@ import (
 	"github.com/youmark/pkcs8"
 )
 
-type MapClaims jwt.MapClaims
-
 // GinJWTMiddleware provides a Json-Web-Token authentication implementation. On failure, a 401 HTTP response
 // is returned. On success, the wrapped middleware is called, and the userID is made available as
 // c.Get("userID").(string).
@@ -62,7 +60,7 @@ type GinJWTMiddleware struct {
 	// Note that the payload is not encrypted.
 	// The attributes mentioned on jwt.io can't be used as keys for the map.
 	// Optional, by default no additional data will be set.
-	PayloadFunc func(data interface{}) MapClaims
+	PayloadFunc func(data interface{}) jwt.MapClaims
 
 	// User can define own Unauthorized func.
 	Unauthorized func(c *gin.Context, code int, message string)
@@ -501,7 +499,7 @@ func (mw *GinJWTMiddleware) middlewareImpl(c *gin.Context) {
 }
 
 // GetClaimsFromJWT get claims from JWT token
-func (mw *GinJWTMiddleware) GetClaimsFromJWT(c *gin.Context) (MapClaims, error) {
+func (mw *GinJWTMiddleware) GetClaimsFromJWT(c *gin.Context) (jwt.MapClaims, error) {
 	token, err := mw.ParseToken(c)
 	if err != nil {
 		return nil, err
@@ -513,7 +511,7 @@ func (mw *GinJWTMiddleware) GetClaimsFromJWT(c *gin.Context) (MapClaims, error) 
 		}
 	}
 
-	claims := MapClaims{}
+	claims := jwt.MapClaims{}
 	for key, value := range token.Claims.(jwt.MapClaims) {
 		claims[key] = value
 	}
@@ -814,22 +812,22 @@ func (mw *GinJWTMiddleware) unauthorized(c *gin.Context, code int, message strin
 }
 
 // ExtractClaims help to extract the JWT claims
-func ExtractClaims(c *gin.Context) MapClaims {
+func ExtractClaims(c *gin.Context) jwt.MapClaims {
 	claims, exists := c.Get("JWT_PAYLOAD")
 	if !exists {
-		return make(MapClaims)
+		return make(jwt.MapClaims)
 	}
 
-	return claims.(MapClaims)
+	return claims.(jwt.MapClaims)
 }
 
 // ExtractClaimsFromToken help to extract the JWT claims from token
-func ExtractClaimsFromToken(token *jwt.Token) MapClaims {
+func ExtractClaimsFromToken(token *jwt.Token) jwt.MapClaims {
 	if token == nil {
-		return make(MapClaims)
+		return make(jwt.MapClaims)
 	}
 
-	claims := MapClaims{}
+	claims := jwt.MapClaims{}
 	for key, value := range token.Claims.(jwt.MapClaims) {
 		claims[key] = value
 	}

--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -235,9 +235,9 @@ func TestLoginHandler(t *testing.T) {
 	authMiddleware, err := New(&GinJWTMiddleware{
 		Realm: "test zone",
 		Key:   key,
-		PayloadFunc: func(data interface{}) MapClaims {
+		PayloadFunc: func(data interface{}) jwt.MapClaims {
 			// Set custom claim, to be checked in Authorizator method
-			return MapClaims{"testkey": "testval", "exp": 0}
+			return jwt.MapClaims{"testkey": "testval", "exp": 0}
 		},
 		Authenticator: func(c *gin.Context) (interface{}, error) {
 			var loginVals Login
@@ -699,13 +699,13 @@ func TestClaimsDuringAuthorization(t *testing.T) {
 		Key:        key,
 		Timeout:    time.Hour,
 		MaxRefresh: time.Hour * 24,
-		PayloadFunc: func(data interface{}) MapClaims {
-			if v, ok := data.(MapClaims); ok {
+		PayloadFunc: func(data interface{}) jwt.MapClaims {
+			if v, ok := data.(jwt.MapClaims); ok {
 				return v
 			}
 
 			if reflect.TypeOf(data).String() != "string" {
-				return MapClaims{}
+				return jwt.MapClaims{}
 			}
 
 			var testkey string
@@ -719,7 +719,7 @@ func TestClaimsDuringAuthorization(t *testing.T) {
 			}
 			// Set custom claim, to be checked in Authorizator method
 			now := time.Now()
-			return MapClaims{
+			return jwt.MapClaims{
 				"identity": data.(string),
 				"testkey":  testkey,
 				"exp":      now.Add(time.Hour).Unix(),
@@ -769,7 +769,7 @@ func TestClaimsDuringAuthorization(t *testing.T) {
 	r := gofight.New()
 	handler := ginHandler(authMiddleware)
 
-	userToken, _, _ := authMiddleware.TokenGenerator(MapClaims{
+	userToken, _, _ := authMiddleware.TokenGenerator(jwt.MapClaims{
 		"identity": "administrator",
 	})
 
@@ -820,7 +820,7 @@ func TestClaimsDuringAuthorization(t *testing.T) {
 		})
 }
 
-func ConvertClaims(claims MapClaims) map[string]interface{} {
+func ConvertClaims(claims jwt.MapClaims) map[string]interface{} {
 	return map[string]interface{}{}
 }
 
@@ -864,7 +864,7 @@ func TestEmptyClaims(t *testing.T) {
 			assert.Equal(t, http.StatusUnauthorized, r.Code)
 		})
 
-	assert.Empty(t, MapClaims{})
+	assert.Empty(t, jwt.MapClaims{})
 }
 
 func TestUnauthorized(t *testing.T) {
@@ -1305,8 +1305,8 @@ func TestCheckTokenString(t *testing.T) {
 		Unauthorized: func(c *gin.Context, code int, message string) {
 			c.String(code, message)
 		},
-		PayloadFunc: func(data interface{}) MapClaims {
-			if v, ok := data.(MapClaims); ok {
+		PayloadFunc: func(data interface{}) jwt.MapClaims {
+			if v, ok := data.(jwt.MapClaims); ok {
 				return v
 			}
 
@@ -1318,7 +1318,7 @@ func TestCheckTokenString(t *testing.T) {
 
 	r := gofight.New()
 
-	userToken, _, _ := authMiddleware.TokenGenerator(MapClaims{
+	userToken, _, _ := authMiddleware.TokenGenerator(jwt.MapClaims{
 		"identity": "admin",
 	})
 
@@ -1347,7 +1347,7 @@ func TestCheckTokenString(t *testing.T) {
 
 	_, err = authMiddleware.ParseTokenString(userToken)
 	assert.Error(t, err)
-	assert.Equal(t, MapClaims{}, ExtractClaimsFromToken(nil))
+	assert.Equal(t, jwt.MapClaims{}, ExtractClaimsFromToken(nil))
 }
 
 func TestLogout(t *testing.T) {


### PR DESCRIPTION
- Remove the MapClaims type alias and use jwt.MapClaims directly throughout the codebase
- Update all function signatures and implementations to replace MapClaims with jwt.MapClaims
- Refactor related tests to use jwt.MapClaims instead of MapClaims

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified the usage of JWT claims by replacing the custom type alias with the standard `jwt.MapClaims` type throughout the application and tests. No changes to logic or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->