### PR TITLE
feat: enhance logout endpoint with customizable responses and JWT access

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,31 @@ http -f GET localhost:8000/auth/hello "Authorization:Bearer xxxxxxxxx"  "Content
 }
 ```
 
+### Logout
+
+Login first, then call the logout endpoint with the JWT token:
+
+```sh
+# First login to get the JWT token
+http -v --json POST localhost:8000/login username=admin password=admin
+
+# Use the returned JWT token to logout (replace xxxxxxxxx with actual token)
+http -f POST localhost:8000/auth/logout "Authorization:Bearer xxxxxxxxx" "Content-Type: application/json"
+```
+
+**Response:**
+
+```json
+{
+  "code": 200,
+  "logged_out_user": "admin",
+  "message": "Successfully logged out",
+  "user_info": "admin"
+}
+```
+
+The logout response demonstrates that JWT claims are now accessible during logout through `jwt.ExtractClaims(c)`, allowing developers to access user information for logging, auditing, or cleanup purposes.
+
 ---
 
 ## Cookie Token

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -155,6 +155,31 @@ http -f GET localhost:8000/auth/hello "Authorization:Bearer xxxxxxxxx"  "Content
 }
 ```
 
+### 登出
+
+先登录获取 JWT Token，然后调用登出端点：
+
+```sh
+# 先登录获取 JWT Token
+http -v --json POST localhost:8000/login username=admin password=admin
+
+# 使用获取的 JWT Token 来登出（将 xxxxxxxxx 替换为实际的 Token）
+http -f POST localhost:8000/auth/logout "Authorization:Bearer xxxxxxxxx" "Content-Type: application/json"
+```
+
+**响应：**
+
+```json
+{
+  "code": 200,
+  "logged_out_user": "admin",
+  "message": "Successfully logged out",
+  "user_info": "admin"
+}
+```
+
+登出响应展示了 JWT 声明现在可以通过 `jwt.ExtractClaims(c)` 在登出期间访问，让开发者能够获取用户信息用于日志记录、审计或清理操作。
+
 ---
 
 ## Cookie Token

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -155,6 +155,31 @@ http -f GET localhost:8000/auth/hello "Authorization:Bearer xxxxxxxxx"  "Content
 }
 ```
 
+### 登出
+
+先登入取得 JWT Token，然後呼叫登出端點：
+
+```sh
+# 先登入取得 JWT Token
+http -v --json POST localhost:8000/login username=admin password=admin
+
+# 使用取得的 JWT Token 來登出（將 xxxxxxxxx 替換為實際的 Token）
+http -f POST localhost:8000/auth/logout "Authorization:Bearer xxxxxxxxx" "Content-Type: application/json"
+```
+
+**回應：**
+
+```json
+{
+  "code": 200,
+  "logged_out_user": "admin",
+  "message": "Successfully logged out",
+  "user_info": "admin"
+}
+```
+
+登出回應展示了 JWT 聲明現在可以透過 `jwt.ExtractClaims(c)` 在登出期間存取，讓開發者能夠取得使用者資訊用於日誌記錄、稽核或清理作業。
+
 ---
 
 ## Cookie Token

--- a/_example/basic/server.go
+++ b/_example/basic/server.go
@@ -84,6 +84,7 @@ func initParams() *jwt.GinJWTMiddleware {
 		Authenticator:   authenticator(),
 		Authorizator:    authorizator(),
 		Unauthorized:    unauthorized(),
+		LogoutResponse:  logoutResponse(),
 		TokenLookup:     "header: Authorization, query: token, cookie: jwt",
 		// TokenLookup: "query:token",
 		// TokenLookup: "cookie:token",
@@ -147,6 +148,29 @@ func unauthorized() func(c *gin.Context, code int, message string) {
 			"code":    code,
 			"message": message,
 		})
+	}
+}
+
+func logoutResponse() func(c *gin.Context, code int) {
+	return func(c *gin.Context, code int) {
+		// This demonstrates that claims are now accessible during logout
+		claims := jwt.ExtractClaims(c)
+		user, exists := c.Get(identityKey)
+
+		response := gin.H{
+			"code":    code,
+			"message": "Successfully logged out",
+		}
+
+		// Show that we can access user information during logout
+		if len(claims) > 0 {
+			response["logged_out_user"] = claims[identityKey]
+		}
+		if exists {
+			response["user_info"] = user.(*User).UserName
+		}
+
+		c.JSON(code, response)
 	}
 }
 

--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -626,6 +626,17 @@ func (mw *GinJWTMiddleware) extractRefreshToken(c *gin.Context) string {
 
 // LogoutHandler can be used by clients to remove the jwt cookie and revoke refresh token
 func (mw *GinJWTMiddleware) LogoutHandler(c *gin.Context) {
+	// Extract JWT claims to make them available in LogoutResponse
+	// This allows developers to access user information during logout
+	claims, err := mw.GetClaimsFromJWT(c)
+	if err == nil {
+		c.Set("JWT_PAYLOAD", claims)
+		identity := mw.IdentityHandler(c)
+		if identity != nil {
+			c.Set(mw.IdentityKey, identity)
+		}
+	}
+
 	// Handle refresh token revocation (RFC 6749 compliant)
 	refreshToken := mw.extractRefreshToken(c)
 	if refreshToken != "" {


### PR DESCRIPTION
- Add documentation and code samples for the logout endpoint in English and Chinese READMEs
- Introduce a customizable logout response function to provide user details at logout
- Make JWT claims available during logout, enabling access to user information for logging and audit purposes

fix https://github.com/appleboy/gin-jwt/issues/285

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Logout handlers now receive JWT claims, enabling richer, user-aware logout responses. Backward compatible.

* Documentation
  * Added Logout usage guides in English, Simplified Chinese, and Traditional Chinese, detailing the login→logout flow, required headers, example curl/httpie commands, and sample JSON responses.
  * Updated examples to demonstrate a customized logout response payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->