### PR TITLE
refactor: standardize middleware naming to Authorizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ func initParams() *jwt.GinJWTMiddleware {
 
     IdentityHandler: identityHandler(),
     Authenticator:   authenticator(),
-    Authorizator:    authorizator(),
+    Authorizer:    authorizator(),
     Unauthorized:    unauthorized(),
     TokenLookup:     "header: Authorization, query: token, cookie: jwt",
     // TokenLookup: "query:token",
@@ -662,13 +662,13 @@ Signature: `func(c *gin.Context, token *core.Token)`
 
 PROVIDED: `MiddlewareFunc`
 
-This is gin middleware that should be used within any endpoints that require the jwt token to be present. This middleware will parse the request headers for the token if it exists, and check that the jwt token is valid (not expired, correct signature). Then it will call `IdentityHandler` followed by `Authorizator`. If `Authorizator` passes and all of the previous token validity checks passed, the middleware will continue the request. If any of these checks fail, the `Unauthorized` function is used (explained below).
+This is gin middleware that should be used within any endpoints that require the jwt token to be present. This middleware will parse the request headers for the token if it exists, and check that the jwt token is valid (not expired, correct signature). Then it will call `IdentityHandler` followed by `Authorizer`. If `Authorizer` passes and all of the previous token validity checks passed, the middleware will continue the request. If any of these checks fail, the `Unauthorized` function is used (explained below).
 
 OPTIONAL: `IdentityHandler`
 
-The default of this function is likely sufficient for your needs. The purpose of this function is to fetch the user identity from claims embedded within the jwt token, and pass this identity value to `Authorizator`. This function assumes [`IdentityKey`: some_user_identity] is one of the attributes embedded within the claims of the jwt token (determined by `PayloadFunc`).
+The default of this function is likely sufficient for your needs. The purpose of this function is to fetch the user identity from claims embedded within the jwt token, and pass this identity value to `Authorizer`. This function assumes [`IdentityKey`: some_user_identity] is one of the attributes embedded within the claims of the jwt token (determined by `PayloadFunc`).
 
-OPTIONAL: `Authorizator`
+OPTIONAL: `Authorizer`
 
 Given the user identity value (`data` parameter) and the gin context, this function should check if the user is authorized to be reaching this endpoint (on the endpoints where the `MiddlewareFunc` applies). This function should likely use `ExtractClaims` to check if the user has the sufficient permissions to reach this endpoint, as opposed to hitting the database on every request. This function should return true if the user is authorized to continue through with the request, or false if they are not authorized (where `Unauthorized` will be called).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -500,13 +500,13 @@ CookieSameSite:   http.SameSiteDefaultMode, // SameSiteDefaultMode, SameSiteLaxM
 
   - 从 header/cookie/query 解析 Token
   - 验证 Token
-  - 调用 `IdentityHandler` 与 `Authorizator`
+  - 调用 `IdentityHandler` 与 `Authorizer`
   - 验证失败则调用 `Unauthorized`
 
 - **可选：** `IdentityHandler`  
   从 JWT Claims 获取用户身份。
 
-- **可选：** `Authorizator`  
+- **可选：** `Authorizer`  
   检查用户是否有权限访问该端点。
 
 ---

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -500,13 +500,13 @@ CookieSameSite:   http.SameSiteDefaultMode, // SameSiteDefaultMode, SameSiteLaxM
 
   - 從 header/cookie/query 解析 Token
   - 驗證 Token
-  - 呼叫 `IdentityHandler` 與 `Authorizator`
+  - 呼叫 `IdentityHandler` 與 `Authorizer`
   - 驗證失敗則呼叫 `Unauthorized`
 
 - **可選：** `IdentityHandler`  
   從 JWT Claims 取得使用者身份。
 
-- **可選：** `Authorizator`  
+- **可選：** `Authorizer`  
   檢查使用者是否有權限存取該端點。
 
 ---

--- a/_example/basic/server.go
+++ b/_example/basic/server.go
@@ -82,7 +82,7 @@ func initParams() *jwt.GinJWTMiddleware {
 
 		IdentityHandler: identityHandler(),
 		Authenticator:   authenticator(),
-		Authorizator:    authorizator(),
+		Authorizer:      authorizator(),
 		Unauthorized:    unauthorized(),
 		LogoutResponse:  logoutResponse(),
 		TokenLookup:     "header: Authorization, query: token, cookie: jwt",

--- a/_example/redis_simple/main.go
+++ b/_example/redis_simple/main.go
@@ -65,7 +65,7 @@ func main() {
 			return nil, jwt.ErrFailedAuthentication
 		},
 
-		Authorizator: func(c *gin.Context, data any) bool {
+		Authorizer: func(c *gin.Context, data any) bool {
 			if v, ok := data.(*User); ok && v.UserName == "admin" {
 				return true
 			}

--- a/_example/redis_store/main.go
+++ b/_example/redis_store/main.go
@@ -61,7 +61,7 @@ func main() {
 
 			return nil, jwt.ErrFailedAuthentication
 		},
-		Authorizator: func(c *gin.Context, data any) bool {
+		Authorizer: func(c *gin.Context, data any) bool {
 			if v, ok := data.(*User); ok && v.UserName == "admin" {
 				return true
 			}

--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -58,7 +58,7 @@ type GinJWTMiddleware struct {
 	// Callback function that should perform the authorization of the authenticated user. Called
 	// only after an authentication success. Must return true on success, false on failure.
 	// Optional, default to success.
-	Authorizator func(c *gin.Context, data any) bool
+	Authorizer func(c *gin.Context, data any) bool
 
 	// Callback function that will be called during login.
 	// Using this function it is possible to add additional payload data to the webtoken.
@@ -382,8 +382,8 @@ func (mw *GinJWTMiddleware) MiddlewareInit() error {
 		mw.TokenHeadName = "Bearer"
 	}
 
-	if mw.Authorizator == nil {
-		mw.Authorizator = func(c *gin.Context, data any) bool {
+	if mw.Authorizer == nil {
+		mw.Authorizer = func(c *gin.Context, data any) bool {
 			return true
 		}
 	}
@@ -520,7 +520,7 @@ func (mw *GinJWTMiddleware) middlewareImpl(c *gin.Context) {
 		c.Set(mw.IdentityKey, identity)
 	}
 
-	if !mw.Authorizator(c, identity) {
+	if !mw.Authorizer(c, identity) {
 		mw.unauthorized(c, http.StatusForbidden, mw.HTTPStatusMessageFunc(c,ErrForbidden))
 		return
 	}

--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -258,7 +258,7 @@ func TestLoginHandler(t *testing.T) {
 		Realm: "test zone",
 		Key:   key,
 		PayloadFunc: func(data any) jwt.MapClaims {
-			// Set custom claim, to be checked in Authorizator method
+			// Set custom claim, to be checked in Authorizer method
 			return jwt.MapClaims{"testkey": "testval", "exp": 0}
 		},
 		Authenticator: func(c *gin.Context) (any, error) {
@@ -273,7 +273,7 @@ func TestLoginHandler(t *testing.T) {
 			}
 			return "", ErrFailedAuthentication
 		},
-		Authorizator: func(c *gin.Context, user any) bool {
+		Authorizer: func(c *gin.Context, user any) bool {
 			return true
 		},
 		LoginResponse: func(c *gin.Context, token *core.Token) {
@@ -667,7 +667,7 @@ func TestExpiredTokenOnRefreshHandler(t *testing.T) {
 	}
 }
 
-func TestAuthorizator(t *testing.T) {
+func TestAuthorizer(t *testing.T) {
 	// the middleware to test
 	authMiddleware, _ := New(&GinJWTMiddleware{
 		Realm:         "test zone",
@@ -675,7 +675,7 @@ func TestAuthorizator(t *testing.T) {
 		Timeout:       time.Hour,
 		MaxRefresh:    time.Hour * 24,
 		Authenticator: defaultAuthenticator,
-		Authorizator: func(c *gin.Context, data any) bool {
+		Authorizer: func(c *gin.Context, data any) bool {
 			return data.(string) == "admin"
 		},
 	})
@@ -752,7 +752,7 @@ func TestClaimsDuringAuthorization(t *testing.T) {
 			case "Guest":
 				testkey = ""
 			}
-			// Set custom claim, to be checked in Authorizator method
+			// Set custom claim, to be checked in Authorizer method
 			now := time.Now()
 			return jwt.MapClaims{
 				"identity": data.(string),
@@ -782,7 +782,7 @@ func TestClaimsDuringAuthorization(t *testing.T) {
 
 			return "Guest", ErrFailedAuthentication
 		},
-		Authorizator: func(c *gin.Context, user any) bool {
+		Authorizer: func(c *gin.Context, user any) bool {
 			jwtClaims := ExtractClaims(c)
 
 			if jwtClaims["identity"] == "administrator" {
@@ -1150,7 +1150,7 @@ func TestSendAuthorizationBool(t *testing.T) {
 		MaxRefresh:        time.Hour * 24,
 		Authenticator:     defaultAuthenticator,
 		SendAuthorization: true,
-		Authorizator: func(c *gin.Context, data any) bool {
+		Authorizer: func(c *gin.Context, data any) bool {
 			return data.(string) == "admin"
 		},
 	})
@@ -1188,7 +1188,7 @@ func TestExpiredTokenOnAuth(t *testing.T) {
 		MaxRefresh:        time.Hour * 24,
 		Authenticator:     defaultAuthenticator,
 		SendAuthorization: true,
-		Authorizator: func(c *gin.Context, data any) bool {
+		Authorizer: func(c *gin.Context, data any) bool {
 			return data.(string) == "admin"
 		},
 		TimeFunc: func() time.Time {
@@ -1456,7 +1456,7 @@ func TestGenerateTokenPair(t *testing.T) {
 				"identity": data,
 			}
 		},
-		Authorizator: func(c *gin.Context, data any) bool {
+		Authorizer: func(c *gin.Context, data any) bool {
 			return data == "admin"
 		},
 		Unauthorized: func(c *gin.Context, code int, message string) {


### PR DESCRIPTION
- Rename the middleware configuration field from Authorizator to Authorizer throughout the codebase and documentation
- Update all references and usage examples to use Authorizer instead of Authorizator
- Revise test functions and comments to reflect the Authorizer naming change

fix https://github.com/appleboy/gin-jwt/issues/295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed the public authorization callback from “Authorizator” to “Authorizer.” Behavior unchanged, but you may need to update your configuration code.

- Documentation
  - Updated English, Simplified Chinese, and Traditional Chinese guides to use “Authorizer” and aligned middleware flow descriptions.

- Examples
  - Updated example configurations to reference “Authorizer.”

- Tests
  - Renamed tests and updated usages to reflect “Authorizer.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->