### PR TITLE
refactor: adopt context-aware token operations throughout codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ The `TokenGenerator` functionality allows you to create JWT tokens directly with
 package main
 
 import (
+    "context"
     "fmt"
     "log"
     "time"
@@ -356,9 +357,12 @@ func main() {
         log.Fatal("JWT Error:" + err.Error())
     }
 
+    // Create context for token operations
+    ctx := context.Background()
+
     // Generate a complete token pair (access + refresh tokens)
     userData := "user123"
-    tokenPair, err := authMiddleware.TokenGenerator(userData)
+    tokenPair, err := authMiddleware.TokenGenerator(ctx, userData)
     if err != nil {
         log.Fatal("Failed to generate token pair:", err)
     }
@@ -392,7 +396,7 @@ Use `TokenGeneratorWithRevocation` to refresh tokens and automatically revoke ol
 
 ```go
 // Refresh with automatic revocation of old token
-newTokenPair, err := authMiddleware.TokenGeneratorWithRevocation(userData, oldRefreshToken)
+newTokenPair, err := authMiddleware.TokenGeneratorWithRevocation(ctx, userData, oldRefreshToken)
 if err != nil {
     log.Fatal("Failed to refresh token:", err)
 }

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -166,6 +166,7 @@ import "github.com/appleboy/gin-jwt/v3"
 package main
 
 import (
+    "context"
     "fmt"
     "log"
     "time"
@@ -191,9 +192,12 @@ func main() {
         log.Fatal("JWT Error:" + err.Error())
     }
 
+    // 创建 Token 操作的 context
+    ctx := context.Background()
+
     // 生成完整的 Token 组（访问 + 刷新 Token）
     userData := "user123"
-    tokenPair, err := authMiddleware.TokenGenerator(userData)
+    tokenPair, err := authMiddleware.TokenGenerator(ctx, userData)
     if err != nil {
         log.Fatal("Failed to generate token pair:", err)
     }

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -166,6 +166,7 @@ import "github.com/appleboy/gin-jwt/v3"
 package main
 
 import (
+    "context"
     "fmt"
     "log"
     "time"
@@ -191,9 +192,12 @@ func main() {
         log.Fatal("JWT Error:" + err.Error())
     }
 
+    // 建立 Token 操作的 context
+    ctx := context.Background()
+
     // 產生完整的 Token 組（存取 + 刷新 Token）
     userData := "user123"
-    tokenPair, err := authMiddleware.TokenGenerator(userData)
+    tokenPair, err := authMiddleware.TokenGenerator(ctx, userData)
     if err != nil {
         log.Fatal("Failed to generate token pair:", err)
     }
@@ -227,7 +231,7 @@ func (t *Token) ExpiresIn() int64 // 回傳到期前的秒數
 
 ```go
 // 刷新並自動撤銷舊 Token
-newTokenPair, err := authMiddleware.TokenGeneratorWithRevocation(userData, oldRefreshToken)
+newTokenPair, err := authMiddleware.TokenGeneratorWithRevocation(ctx, userData, oldRefreshToken)
 if err != nil {
     log.Fatal("Failed to refresh token:", err)
 }

--- a/_example/token_generator/main.go
+++ b/_example/token_generator/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -30,9 +31,12 @@ func main() {
 	// Example user data
 	userData := "user123"
 
+	// Create context for token operations
+	ctx := context.Background()
+
 	// Generate a complete token pair (access + refresh tokens)
 	fmt.Println("=== Generating Token Pair ===")
-	tokenPair, err := authMiddleware.TokenGenerator(userData)
+	tokenPair, err := authMiddleware.TokenGenerator(ctx, userData)
 	if err != nil {
 		log.Fatal("Failed to generate token pair:", err)
 	}
@@ -46,7 +50,7 @@ func main() {
 
 	// Simulate refresh token usage
 	fmt.Println("\n=== Refreshing Token Pair ===")
-	newTokenPair, err := authMiddleware.TokenGeneratorWithRevocation(userData, tokenPair.RefreshToken)
+	newTokenPair, err := authMiddleware.TokenGeneratorWithRevocation(ctx, userData, tokenPair.RefreshToken)
 	if err != nil {
 		log.Fatal("Failed to refresh token pair:", err)
 	}
@@ -57,7 +61,7 @@ func main() {
 
 	// Verify old refresh token is invalid
 	fmt.Println("\n=== Verifying Old Token Revocation ===")
-	_, err = authMiddleware.TokenGeneratorWithRevocation(userData, tokenPair.RefreshToken)
+	_, err = authMiddleware.TokenGeneratorWithRevocation(ctx, userData, tokenPair.RefreshToken)
 	if err != nil {
 		fmt.Printf("Old refresh token correctly rejected: %s\n", err)
 	}

--- a/auth_jwt_redis_test.go
+++ b/auth_jwt_redis_test.go
@@ -401,33 +401,34 @@ func testRedisStoreOperations(t *testing.T, middleware *GinJWTMiddleware) {
 	require.True(t, ok, "should be using Redis store")
 
 	// Test store operations directly
+	ctx := context.Background()
 	testToken := "direct-test-token"
 	testData := map[string]any{"test": "data"}
 	expiry := time.Now().Add(time.Hour)
 
 	// Test Set
-	err := redisStore.Set(testToken, testData, expiry)
+	err := redisStore.Set(ctx, testToken, testData, expiry)
 	assert.NoError(t, err, "direct set should succeed")
 
 	// Test Get
-	retrievedData, err := redisStore.Get(testToken)
+	retrievedData, err := redisStore.Get(ctx, testToken)
 	assert.NoError(t, err, "direct get should succeed")
 	assert.Equal(t, testData, retrievedData, "retrieved data should match")
 
 	// Test Count
-	count, err := redisStore.Count()
+	count, err := redisStore.Count(ctx)
 	assert.NoError(t, err, "count should succeed")
 	assert.GreaterOrEqual(t, count, 1, "count should include our test token")
 
 	// Test Delete
-	err = redisStore.Delete(testToken)
+	err = redisStore.Delete(ctx, testToken)
 	assert.NoError(t, err, "direct delete should succeed")
 
 	// Verify deletion - wait for cache TTL to expire
 	time.Sleep(100 * time.Millisecond)
 
 	// The Get method should return an error for deleted tokens
-	_, err = redisStore.Get(testToken)
+	_, err = redisStore.Get(ctx, testToken)
 	assert.Error(t, err, "token should not exist after deletion")
 }
 

--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -1,6 +1,7 @@
 package jwt
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -1470,7 +1471,8 @@ func TestTokenGenerator(t *testing.T) {
 	assert.NoError(t, err)
 
 	userData := "admin"
-	tokenPair, err := authMiddleware.TokenGenerator(userData)
+	ctx := context.Background()
+	tokenPair, err := authMiddleware.TokenGenerator(ctx, userData)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, tokenPair)
@@ -1510,18 +1512,19 @@ func TestTokenGeneratorWithRevocation(t *testing.T) {
 	assert.NoError(t, err)
 
 	userData := "admin"
+	ctx := context.Background()
 
 	// Generate first token pair
-	oldTokenPair, err := authMiddleware.TokenGenerator(userData)
+	oldTokenPair, err := authMiddleware.TokenGenerator(ctx, userData)
 	assert.NoError(t, err)
 
 	// Verify old refresh token exists in store
-	storedData, err := authMiddleware.validateRefreshToken(oldTokenPair.RefreshToken)
+	storedData, err := authMiddleware.validateRefreshToken(ctx, oldTokenPair.RefreshToken)
 	assert.NoError(t, err)
 	assert.Equal(t, userData, storedData)
 
 	// Generate new token pair with revocation
-	newTokenPair, err := authMiddleware.TokenGeneratorWithRevocation(userData, oldTokenPair.RefreshToken)
+	newTokenPair, err := authMiddleware.TokenGeneratorWithRevocation(ctx, userData, oldTokenPair.RefreshToken)
 	assert.NoError(t, err)
 	assert.NotNil(t, newTokenPair)
 
@@ -1529,21 +1532,21 @@ func TestTokenGeneratorWithRevocation(t *testing.T) {
 	assert.NotEqual(t, oldTokenPair.RefreshToken, newTokenPair.RefreshToken)
 
 	// Verify old refresh token is revoked
-	_, err = authMiddleware.validateRefreshToken(oldTokenPair.RefreshToken)
+	_, err = authMiddleware.validateRefreshToken(ctx, oldTokenPair.RefreshToken)
 	assert.Error(t, err)
 
 	// Verify new refresh token works
-	storedData, err = authMiddleware.validateRefreshToken(newTokenPair.RefreshToken)
+	storedData, err = authMiddleware.validateRefreshToken(ctx, newTokenPair.RefreshToken)
 	assert.NoError(t, err)
 	assert.Equal(t, userData, storedData)
 
 	// Test revoking already revoked token (should not fail)
-	anotherTokenPair, err := authMiddleware.TokenGeneratorWithRevocation(userData, oldTokenPair.RefreshToken)
+	anotherTokenPair, err := authMiddleware.TokenGeneratorWithRevocation(ctx, userData, oldTokenPair.RefreshToken)
 	assert.NoError(t, err)
 	assert.NotNil(t, anotherTokenPair)
 
 	// Test revoking non-existent token (should not fail)
-	finalTokenPair, err := authMiddleware.TokenGeneratorWithRevocation(userData, "non_existent_token")
+	finalTokenPair, err := authMiddleware.TokenGeneratorWithRevocation(ctx, userData, "non_existent_token")
 	assert.NoError(t, err)
 	assert.NotNil(t, finalTokenPair)
 }
@@ -1562,7 +1565,8 @@ func TestTokenStruct(t *testing.T) {
 	assert.NoError(t, err)
 
 	userData := "admin"
-	tokenPair, err := authMiddleware.TokenGenerator(userData)
+	ctx := context.Background()
+	tokenPair, err := authMiddleware.TokenGenerator(ctx, userData)
 	assert.NoError(t, err)
 
 	// Test ExpiresIn method

--- a/core/store.go
+++ b/core/store.go
@@ -2,6 +2,7 @@
 package core
 
 import (
+	"context"
 	"errors"
 	"time"
 )
@@ -18,23 +19,23 @@ var (
 type TokenStore interface {
 	// Set stores a refresh token with associated user data and expiration
 	// Returns an error if the operation fails
-	Set(token string, userData any, expiry time.Time) error
+	Set(ctx context.Context, token string, userData any, expiry time.Time) error
 
 	// Get retrieves user data associated with a refresh token
 	// Returns ErrRefreshTokenNotFound if token doesn't exist or is expired
-	Get(token string) (any, error)
+	Get(ctx context.Context, token string) (any, error)
 
 	// Delete removes a refresh token from storage
 	// Returns an error if the operation fails, but should not error if token doesn't exist
-	Delete(token string) error
+	Delete(ctx context.Context, token string) error
 
 	// Cleanup removes expired tokens (optional, for cleanup routines)
 	// Returns the number of tokens cleaned up and any error encountered
-	Cleanup() (int, error)
+	Cleanup(ctx context.Context) (int, error)
 
 	// Count returns the total number of active refresh tokens
 	// Useful for monitoring and debugging
-	Count() (int, error)
+	Count(ctx context.Context) (int, error)
 }
 
 // RefreshTokenData holds the data stored with each refresh token

--- a/store/memory.go
+++ b/store/memory.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"time"
@@ -26,7 +27,7 @@ func NewInMemoryRefreshTokenStore() *InMemoryRefreshTokenStore {
 }
 
 // Set stores a refresh token with associated user data and expiration
-func (s *InMemoryRefreshTokenStore) Set(token string, userData any, expiry time.Time) error {
+func (s *InMemoryRefreshTokenStore) Set(ctx context.Context, token string, userData any, expiry time.Time) error {
 	if token == "" {
 		return errors.New("token cannot be empty")
 	}
@@ -44,7 +45,7 @@ func (s *InMemoryRefreshTokenStore) Set(token string, userData any, expiry time.
 }
 
 // Get retrieves user data associated with a refresh token
-func (s *InMemoryRefreshTokenStore) Get(token string) (any, error) {
+func (s *InMemoryRefreshTokenStore) Get(ctx context.Context, token string) (any, error) {
 	if token == "" {
 		return nil, ErrRefreshTokenNotFound
 	}
@@ -69,7 +70,7 @@ func (s *InMemoryRefreshTokenStore) Get(token string) (any, error) {
 }
 
 // Delete removes a refresh token from storage
-func (s *InMemoryRefreshTokenStore) Delete(token string) error {
+func (s *InMemoryRefreshTokenStore) Delete(ctx context.Context, token string) error {
 	if token == "" {
 		return nil // No error for empty token deletion
 	}
@@ -82,7 +83,7 @@ func (s *InMemoryRefreshTokenStore) Delete(token string) error {
 }
 
 // Cleanup removes expired tokens and returns the number of tokens cleaned up
-func (s *InMemoryRefreshTokenStore) Cleanup() (int, error) {
+func (s *InMemoryRefreshTokenStore) Cleanup(ctx context.Context) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -100,7 +101,7 @@ func (s *InMemoryRefreshTokenStore) Cleanup() (int, error) {
 }
 
 // Count returns the total number of active refresh tokens
-func (s *InMemoryRefreshTokenStore) Count() (int, error) {
+func (s *InMemoryRefreshTokenStore) Count(ctx context.Context) (int, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 

--- a/store/redis_test.go
+++ b/store/redis_test.go
@@ -90,30 +90,30 @@ func testBasicOperations(t *testing.T, store *RedisRefreshTokenStore) {
 	expiry := time.Now().Add(time.Hour)
 
 	// Test Set
-	err := store.Set(token, userData, expiry)
+	err := store.Set(ctx, token, userData, expiry)
 	assert.NoError(t, err, "Set should not return error")
 
 	// Test Get
-	retrievedData, err := store.Get(token)
+	retrievedData, err := store.Get(ctx, token)
 	assert.NoError(t, err, "Get should not return error")
 	assert.Equal(t, userData, retrievedData, "Retrieved data should match stored data")
 
 	// Test Delete
-	err = store.Delete(token)
+	err = store.Delete(ctx, token)
 	assert.NoError(t, err, "Delete should not return error")
 
 	// Verify deletion
-	_, err = store.Get(token)
+	_, err = store.Get(ctx, token)
 	assert.ErrorIs(t, err, core.ErrRefreshTokenNotFound, "Token should not be found after deletion")
 
 	// Test empty token
-	err = store.Set("", userData, expiry)
+	err = store.Set(ctx, "", userData, expiry)
 	assert.Error(t, err, "Set with empty token should return error")
 
-	_, err = store.Get("")
+	_, err = store.Get(ctx, "")
 	assert.ErrorIs(t, err, core.ErrRefreshTokenNotFound, "Get with empty token should return not found error")
 
-	err = store.Delete("")
+	err = store.Delete(ctx, "")
 	assert.NoError(t, err, "Delete with empty token should not return error")
 
 	// Test ping
@@ -131,11 +131,11 @@ func testExpiration(t *testing.T, store *RedisRefreshTokenStore) {
 
 	// Set token with very short expiry
 	shortExpiry := time.Now().Add(100 * time.Millisecond)
-	err := store.Set(token, userData, shortExpiry)
+	err := store.Set(ctx, token, userData, shortExpiry)
 	assert.NoError(t, err, "Set should not return error")
 
 	// Token should be available immediately
-	retrievedData, err := store.Get(token)
+	retrievedData, err := store.Get(ctx, token)
 	assert.NoError(t, err, "Get should not return error immediately after set")
 	assert.Equal(t, userData, retrievedData, "Retrieved data should match stored data")
 
@@ -143,7 +143,7 @@ func testExpiration(t *testing.T, store *RedisRefreshTokenStore) {
 	time.Sleep(200 * time.Millisecond)
 
 	// Token should be expired
-	_, err = store.Get(token)
+	_, err = store.Get(ctx, token)
 	assert.ErrorIs(t, err, core.ErrRefreshTokenExpired, "Token should be expired")
 
 	// Clean up test data
@@ -160,22 +160,22 @@ func testCleanup(t *testing.T, store *RedisRefreshTokenStore) {
 	// Set tokens with past expiry (already expired)
 	pastExpiry := time.Now().Add(-time.Hour)
 	for _, token := range tokens[:2] {
-		err := store.Set(token, userData, pastExpiry)
+		err := store.Set(ctx, token, userData, pastExpiry)
 		assert.NoError(t, err, "Set should not return error")
 	}
 
 	// Set one token with future expiry
 	futureExpiry := time.Now().Add(time.Hour)
-	err := store.Set(tokens[2], userData, futureExpiry)
+	err := store.Set(ctx, tokens[2], userData, futureExpiry)
 	assert.NoError(t, err, "Set should not return error")
 
 	// Run cleanup
-	cleaned, err := store.Cleanup()
+	cleaned, err := store.Cleanup(ctx)
 	assert.NoError(t, err, "Cleanup should not return error")
 	assert.GreaterOrEqual(t, cleaned, 0, "Cleanup should return non-negative count")
 
 	// Verify that non-expired token still exists
-	_, err = store.Get(tokens[2])
+	_, err = store.Get(ctx, tokens[2])
 	assert.NoError(t, err, "Non-expired token should still exist after cleanup")
 
 	// Clean up test data
@@ -194,7 +194,7 @@ func testCount(t *testing.T, store *RedisRefreshTokenStore) {
 	}
 
 	// Get initial count
-	initialCount, err := store.Count()
+	initialCount, err := store.Count(ctx)
 	assert.NoError(t, err, "Count should not return error")
 
 	// Add some tokens
@@ -202,18 +202,18 @@ func testCount(t *testing.T, store *RedisRefreshTokenStore) {
 	expiry := time.Now().Add(time.Hour)
 
 	for i, token := range keys {
-		err := store.Set(token, fmt.Sprintf("%s-%d", userData, i), expiry)
+		err := store.Set(ctx, token, fmt.Sprintf("%s-%d", userData, i), expiry)
 		assert.NoError(t, err, "Set should not return error")
 	}
 
 	// Count should increase
-	newCount, err := store.Count()
+	newCount, err := store.Count(ctx)
 	assert.NoError(t, err, "Count should not return error")
 	assert.GreaterOrEqual(t, newCount, initialCount+len(keys), "Count should include new tokens")
 
 	// Clean up test data
 	for _, token := range keys {
-		err := store.Delete(token)
+		err := store.Delete(ctx, token)
 		assert.NoError(t, err, "Delete should not return error")
 	}
 }
@@ -225,19 +225,19 @@ func testClientSideCache(t *testing.T, store *RedisRefreshTokenStore) {
 	expiry := time.Now().Add(time.Hour)
 
 	// Set token
-	err := store.Set(token, userData, expiry)
+	err := store.Set(ctx, token, userData, expiry)
 	assert.NoError(t, err, "Set should not return error")
 
 	// First get (should populate cache)
 	start1 := time.Now()
-	retrievedData1, err := store.Get(token)
+	retrievedData1, err := store.Get(ctx, token)
 	duration1 := time.Since(start1)
 	assert.NoError(t, err, "First Get should not return error")
 	assert.Equal(t, userData, retrievedData1, "First retrieved data should match stored data")
 
 	// Second get (should use cache and be faster)
 	start2 := time.Now()
-	retrievedData2, err := store.Get(token)
+	retrievedData2, err := store.Get(ctx, token)
 	duration2 := time.Since(start2)
 	assert.NoError(t, err, "Second Get should not return error")
 	assert.Equal(t, userData, retrievedData2, "Second retrieved data should match stored data")
@@ -282,7 +282,7 @@ func TestRedisRefreshTokenStore_InvalidToken(t *testing.T) {
 
 	// Test with expired token in past
 	expiredTime := time.Now().Add(-time.Hour)
-	err = store.Set("expired-token", "data", expiredTime)
+	err = store.Set(context.Background(), "expired-token", "data", expiredTime)
 	assert.Error(t, err, "Should return error when setting token with past expiry time")
 	assert.Contains(t, err.Error(), "expiry time must be in the future", "Error should mention future expiry requirement")
 }


### PR DESCRIPTION
- Refactor token store and middleware methods to accept context for improved cancellation and timeout handling
- Update all usages of token store methods to pass context, including tests and examples
- Revise TokenGenerator and TokenGeneratorWithRevocation signatures to require context
- Update documentation and code comments to reflect context usage in token operations