### PR TITLE
feat: improve WWW-Authenticate header formatting and test coverage

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -964,7 +964,7 @@ func (mw *GinJWTMiddleware) ParseTokenString(token string) (*jwt.Token, error) {
 }
 
 func (mw *GinJWTMiddleware) unauthorized(c *gin.Context, code int, message string) {
-	c.Header("WWW-Authenticate", "JWT realm="+mw.Realm)
+	c.Header("WWW-Authenticate", "JWT realm=\""+mw.Realm+"\"")
 	if !mw.DisabledAbort {
 		c.Abort()
 	}


### PR DESCRIPTION
- Quote the realm in the WWW-Authenticate header for JWT responses (e.g., JWT realm="my realm")
- Add comprehensive tests to verify proper WWW-Authenticate header formatting for various authentication error cases, including custom realms, malformed and expired tokens, missing Bearer prefix, and empty headers
- Ensure the WWW-Authenticate header is not set on successful authentication and authorization
- Add tests to validate header behavior during refresh token errors
- Add tests confirming correct header formatting for different realm values, including defaults and special characters

fix https://github.com/appleboy/gin-jwt/issues/207